### PR TITLE
イベント一覧で「詳細」が改行されていない

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def html_safe_br(str)
+    str.gsub(/\r\n|\r|\n/,"<br />").html_safe
+  end
 end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -8,7 +8,7 @@
 	</tr>
 	<tr>
 		<td>説明</td>
-		<td><%= @event.description %></td>
+		<td><%= html_safe_br @event.description %></td>
 	</tr>
 	<tr>
 		<td>作成ユーザ</td>


### PR DESCRIPTION
とりあえず詳細欄は改行→"<br />"に変換し、ついでにHTMLタグも解釈して表示するように変更しました。
